### PR TITLE
[W-19686981] break up permissions list

### DIFF
--- a/modules/ROOT/pages/_partials/permissions.adoc
+++ b/modules/ROOT/pages/_partials/permissions.adoc
@@ -1,4 +1,3 @@
-
 // tag::pageTitle[]
 = IDP Permissions
 // end::pageTitle[]
@@ -6,8 +5,6 @@
 // tag::permissionsIntro[]
 The following list shows all Anypoint permissions in Access Management under the *Document Actions* category: 
 // end::permissionsIntro[]
-
-// tag::permissionsList[]
 
 // tag::permissionManage[]
 Manage Actions:: Gives a user complete access to IDP and assigns reviewer permission by default for every document action.
@@ -25,5 +22,3 @@ Execute Published Actions:: Enables a user to execute a published document actio
 // Unused permission
 // Configure Connected Apps:: Enables a user to configure a connected app to communicate with IDP.
 // end::permissionConfigure[]
-
-// end::permissionsList[]

--- a/modules/ROOT/pages/permissions.adoc
+++ b/modules/ROOT/pages/permissions.adoc
@@ -3,7 +3,13 @@ include::partial$permissions.adoc[tag=pageTitle]
 
 include::partial$permissions.adoc[tag=permissionsIntro]
 
-include::partial$permissions.adoc[tag=permissionsList]
+include::partial$permissions.adoc[tag=permissionManage]
+
+include::partial$permissions.adoc[tag=permissionBuild]
+
+include::partial$permissions.adoc[tag=permissionExecute]
+
+include::partial$permissions.adoc[tag=permissionConfigure]
 
 == See Also
 


### PR DESCRIPTION
I am working on an sfdocs migration script and it doesn't like nested tagged regions, so I broke them up into individual regions and updated the references. 